### PR TITLE
Image viewing: use kitty if running kitty; use open on OSX

### DIFF
--- a/epr.py
+++ b/epr.py
@@ -114,8 +114,12 @@ VWR_LIST = [
     "firefox"
 ]
 VWR = None
-if sys.platform == "win32":
+if os.environ['TERM'] == "xterm-kitty":
+    VWR = "kitty +kitten icat"
+elif sys.platform == "win32":
     VWR = "start"
+elif sys.platform == "darwin":
+    VWR = "open"
 else:
     for i in VWR_LIST:
         if shutil.which(i) is not None:


### PR DESCRIPTION
Two closely related things:

1.    For users running OSX, the default viewer should be `open`, so added a check for that.
2.   For users on any platform running Kitty as their terminal emulator, the default should be to view the images in the terminal itself, so added a check for that.

You might want to merge (1) but not (2). The way I've implemented support for Kitty is pretty rudimentary, and (if you are interested in supporting this at all!) you might prefer to do it properly, by creating a function that generates a curses window containing a properly sized window, or (even more ambitious) by placing the images inline with the text.