### PR TITLE
Add sxiv to image viewers

### DIFF
--- a/epr.py
+++ b/epr.py
@@ -600,6 +600,7 @@ def find_media_viewer():
     VWR_LIST = [
         "feh",
         "gio",
+        "sxiv",
         "gnome-open",
         "gvfs-open",
         "xdg-open",


### PR DESCRIPTION
I prefer [sxiv](https://github.com/muennich/sxiv#readme) over feh.