### PR TITLE
Modify j/k scrolling to only scroll (w/o sudden page turning)

### DIFF
--- a/epr.py
+++ b/epr.py
@@ -66,8 +66,10 @@ from difflib import SequenceMatcher as SM
 
 
 # key bindings
-SCROLL_DOWN = {curses.KEY_DOWN, ord("j")}
-SCROLL_UP = {curses.KEY_UP, ord("k")}
+SCROLL_DOWN = {curses.KEY_DOWN}
+SCROLL_DOWN_J = {ord("j")}
+SCROLL_UP = {curses.KEY_UP}
+SCROLL_UP_K = {ord("k")}
 HALF_DOWN = {4}
 HALF_UP = {21}
 PAGE_DOWN = {curses.KEY_NPAGE, ord("l"), ord(" "), curses.KEY_RIGHT}
@@ -917,6 +919,11 @@ def reader(stdscr, ebook, index, width, y, pctg):
                     return -1, width, -rows, None
                 else:
                     y = 0
+            elif k in SCROLL_UP_K:
+                if count > 1:
+                    svline = y - 1
+                if y >= count:
+                    y -= count
             elif k in PAGE_UP:
                 if y == 0 and index != 0:
                     return -1, width, -rows, None
@@ -931,6 +938,11 @@ def reader(stdscr, ebook, index, width, y, pctg):
                     return 1, width, 0, None
                 else:
                     y = totlines - rows
+            elif k in SCROLL_DOWN_J:
+                if count > 1:
+                    svline = y + rows - 1
+                if y + count <= totlines - rows:
+                    y += count
             elif k in PAGE_DOWN:
                 if totlines - y - LINEPRSRV > rows:
                     # y = pgdn(y, totlines, rows, LINEPRSRV, count)


### PR DESCRIPTION
When scrolling down to read with vim keybindings, found the 
page would turn suddenly in middle of reading.

This change here simply allows j/k scrolling to only scroll, while
maintaining the original behavior (if desired) for up/down arrow
scrolling -- which makes reading very pleasant : )