### PR TITLE
Fix crash when no media viewer found

### DIFF
--- a/epr.py
+++ b/epr.py
@@ -634,7 +634,7 @@ def find_media_viewer():
                 VWR = [i]
                 break
 
-    if VWR[0] in {"gio"}:
+    if VWR is not None and VWR[0] in {"gio"}:
         VWR.append("open")
 
 


### PR DESCRIPTION
The program should take into account the possibility of no media viewers available.

Without this fix, the program just crashes because it tries to access VWR[0] when VWR is None. This fix leaves VWR as None when no media viewers available, but at least lets the user to read the book.

I assume this will be improved in a future version. So, by now, I leave open_media untouched.