### PR TITLE
fix: use raw strings for regex patterns with escaped brackets

### DIFF
--- a/epr.py
+++ b/epr.py
@@ -870,7 +870,7 @@ def reader(stdscr, ebook, index, width, y, pctg):
 
     pad.keypad(True)
     for n, i in enumerate(src_lines):
-        if re.search("\[IMG:[0-9]+\]", i):
+        if re.search(r"\[IMG:[0-9]+\]", i):
             pad.addstr(n, width//2 - len(i)//2, i, curses.A_REVERSE)
         else:
             pad.addstr(n, 0, i)
@@ -1025,7 +1025,7 @@ def reader(stdscr, ebook, index, width, y, pctg):
             elif k == ord("o") and VWR is not None:
                 gambar, idx = [], []
                 for n, i in enumerate(src_lines[y:y+rows]):
-                    img = re.search("(?<=\[IMG:)[0-9]+(?=\])", i)
+                    img = re.search(r"(?<=\[IMG:)[0-9]+(?=\])", i)
                     if img is not None:
                         gambar.append(img.group())
                         idx.append(n)


### PR DESCRIPTION
Fixed SyntaxWarnings for invalid escape sequences in regex patterns. Two regex patterns with escaped square brackets were using regular strings instead of raw strings, causing DeprecationWarning in Python 3.12+.

Before:
```python
re.search("\[IMG:[0-9]+\]", i)
re.search("(?<=\[IMG:)[0-9]+(?=\])", i)
```

After:
```python
re.search(r"\[IMG:[0-9]+\]", i)
re.search(r"(?<=\[IMG:)[0-9]+(?=\])", i)
```

Added r prefix to make them raw strings, eliminating the deprecation warnings. — Sent via @AmSach bot